### PR TITLE
Fix drawing in titl ebar on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,19 @@ SOURCES = \
 	multiselect.jsm \
 	options.xul \
 	override-bindings.css \
-	skin \
+	skin/base.css \
+	skin/bindings.css \
+	skin/groups.xml \
+	skin/linux/linux.css \
+	skin/osx/closetab-white.png \
+	skin/osx/closetab.png \
+	skin/osx/dropmarker.png \
+	skin/osx/osx.css \
+	skin/osx/twisty.png \
+	skin/win7/dropmarker.png \
+	skin/win7/twisty-collapsed.png \
+	skin/win7/twisty.png \
+	skin/win7/win7.css \
 	tabdatastore.jsm \
 	utils.js \
 	vertical-tabbrowser.xml \

--- a/skin/base.css
+++ b/skin/base.css
@@ -91,6 +91,6 @@ statuspanel:-moz-locale-dir(ltr):not([mirror]) .statuspanel-inner {
 /* XXX this should probably be per-OS, yes? */
 /* XXX if I was smarter I'd find a way to make a swoop on the right side of the bar, under the window buttons */
 /* Maybe not - this conveniently leaves a hit target for dragging. */
-#nav-bar {
+/*#nav-bar {
   margin-right: 100px;
-}
+}*/

--- a/skin/osx/osx.css
+++ b/skin/osx/osx.css
@@ -1,5 +1,23 @@
 @namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
+#nav-bar {
+    margin-left: 60px;
+    margin-right: 22px;
+    margin-top: -22px;
+    background-image: none !important;
+    background-color: transparent !important;
+}
+
+#tab-view-deck {
+    height: 44px !important;
+}
+
+/*
+#navigator-toolbox {
+    background-color: red !important;
+}
+*/
+
 /* Background colour for the tree sidebar (light blue when window is
    active, grey otherwise) */
 .tabbrowser-tabs {

--- a/skin/win7/win7.css
+++ b/skin/win7/win7.css
@@ -1,5 +1,9 @@
 @namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
+#nav-bar {
+    margin-right: 100px;
+}
+
 #verticaltabs-splitter {
     min-width: 3px !important;
     width: 3px !important;


### PR DESCRIPTION
I hacked on the CSS to move the drawing of the address bar, search bar, etc into the title bar area on OSX.
